### PR TITLE
Add support for running `mtr-packet` in a Linux VRF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__
 build
 dist
 *.egg-info
+
+.devcontainer

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `mtrpacket` supports a variety of probe customization options. Time-to-live (TTL) may be explicitly used for `traceroute`-like functionality.  Probes can be sent using a variety of protocols:  ICMP, UDP, TCP and SCTP.  UDP, TCP and SCTP probes may be sent with specific source and destination ports.  Probes can be sent with a particular packet size and payload bit-pattern. On Linux, probes can be sent with a routing "mark".
 
-`mtrpacket` works on Linux, MacOS, Windows (under Cygwin) and various Unix systems.  Requirements are Python 3.5 (or newer) and `mtr`  0.88 (or newer).   `mtr` is distributed with many Linux distributions -- you may have it installed already.  For other operating systems, see [the mtr Github repository](https://github.com/traviscross/mtr).
+`mtrpacket` works on Linux, MacOS, Windows (under Cygwin) and various Unix systems.  Requirements are Python 3.5 (or newer) and `mtr` 0.88 (or newer).  Optionally, `iproute2` 4.10.0 (or newer) for command prefix support that allows `mtr-packet` to run in more complex network environments.  `mtr` is distributed with many Linux distributions -- you may have it installed already.  For other operating systems, see [the mtr Github repository](https://github.com/traviscross/mtr).
 
 ## Installation
 

--- a/examples/vrf_ping.py
+++ b/examples/vrf_ping.py
@@ -1,0 +1,40 @@
+import asyncio
+import sys
+import mtrpacket
+
+
+# we pass a command prefix to allow mtr-packet access to more complex environments.
+# in this example, mtr-packet is run from within my_vrf using iproute2.
+async def probe(host, command_prefix):
+    async with mtrpacket.MtrPacket(command_prefix=command_prefix) as mtr:
+        result = await mtr.probe(host)
+
+        #  If the ping got a reply, report the IP address and time
+        if result.success:
+            print('reply from {} in {} ms'.format(
+                result.responder, result.time_ms))
+        else:
+            print('no reply ({})'.format(result.result))
+
+
+#  Get a hostname to ping from the commandline
+if len(sys.argv) > 1:
+    hostname = sys.argv[1]
+    command_prefix = sys.argv[2]
+else:
+    print('Usage: python3 ping.py <hostname> "<command prefix>"')
+    sys.exit(1)
+
+
+#  We need asyncio's event loop to run the coroutine
+loop = asyncio.get_event_loop()
+try:
+    probe_coroutine = probe(hostname, command_prefix)
+    try:
+        loop.run_until_complete(probe_coroutine)
+    except mtrpacket.HostResolveError:
+        print("Can't resolve host '{}'".format(hostname))
+finally:
+    loop.close()
+
+# example: python3 vrf_ping.py 8.8.8.8 "ip netns exec myns"

--- a/mtrpacket/__init__.py
+++ b/mtrpacket/__init__.py
@@ -37,12 +37,13 @@ with specific source and destination ports.  Probes can be sent
 with a particular packet size and payload bit-pattern.
 On Linux, probes can be sent with a routing "mark".
 
-When used in conjunction with iproute2, mtrpacket can send probes from
-within a Linux vrf.
+When iproute2 is available, a command prefix can be constructed
+that makes use of various iproute2 functionality to which mtr-packet
+can be called.
 
 mtrpacket works on Linux, MacOS, Windows (with Cygwin) and
 various Unix systems.  Requirements are Python (>= 3.5) and
-mtr (>= 0.88).  iproute2 (>=4.10.0) is required for vrf support.
+mtr (>= 0.88).  iproute2 (>=4.10.0) is required for command prefix support.
 mtr is distributed with many Linux distributions --
 you may have it installed already.  For other operating systems,
 see https://github.com/traviscross/mtr
@@ -289,8 +290,8 @@ class MtrPacket:
         the MTR_PACKET environment variable can be used to specify
         an alternate subprocess executable.
 
-        If the 'vrf' argument is passed to the MtrPacket() constructor,
-        'mtr-packet' is execcuted from within the vrf that is defined.
+        If the 'command_prefix' argument is passed to the MtrPacket() constructor,
+        'mtr-packet' is executed using the command prefix specified.
 
         As an alternative to calling open() explicitly, an 'async with'
         block can be used with the MtrPacket object to open and close the
@@ -302,7 +303,7 @@ class MtrPacket:
         Raises StateError if the subprocess is already open.
 
         Raises SystemError if 'iproute2' cannot be found in the system path
-        while 'vrf' has been passed.
+        while 'command_prefix' has been passed.
         """
 
         if self._opened:

--- a/mtrpacket/__init__.py
+++ b/mtrpacket/__init__.py
@@ -118,8 +118,8 @@ class MtrPacket:
     processed asynchronously, as they arrive.
     """
 
-    def __init__(self, vrf=None):
-        self.vrf = vrf
+    def __init__(self, command_prefix=None):
+        self._command_prefix = command_prefix
         self.process = None
         self._opened = False
         self._command_futures = {}
@@ -312,9 +312,9 @@ class MtrPacket:
         if not mtr_packet_executable:
             mtr_packet_executable = 'mtr-packet'
 
-        if self.vrf is not None:
+        if self._command_prefix is not None:
             if shutil.which('ip') is not None:
-                mtr_packet_executable = f'ip vrf exec {self.vrf} mtr-packet'
+                mtr_packet_executable = f'{self._command_prefix} mtr-packet'
             else:
                 raise SystemError('iproute2 not found')
 


### PR DESCRIPTION
Hi,

I'm hoping you'll accept a small PR that adds support for `mtr-packet` being run in a Linux VRF.  `mtr` has long since supported running in a vrf while called on any Linux system similar to `ip vrf my_vrf exec mtr 8.8.8.8`.  I tested it locally and the only additional requirement would be `iproute2` if the user chose to use the `vrf` argument.

These requirements, and a couple of other small notes have been documented in the PR as well.